### PR TITLE
Handle denominator equal to 0 while finding the row values for the pivot

### DIFF
--- a/main.py
+++ b/main.py
@@ -154,7 +154,13 @@ class Simplex:
         variable = self.variables[selected_var_col]
         L = []
         for i, equation in enumerate(self.equations):
-            L.append(equation.value / variable.equ_values[i])
+            try:
+                # Pivot's value should be >0 
+                # Meaning that if variable.equ_values[i] == 0 the value should be ignored because it can't be the pivot 
+                # To ignore the value we assume that it is equal to 0 (but it could be anything between ]-inf, 0])
+                L.append(equation.value / variable.equ_values[i])
+            except ZeroDivisionError:
+                L.append(0)
 
         # get index of smallest value (positive only)
         row_index = L.index(sorted(filter(lambda x: x > 0, L))[0])


### PR DESCRIPTION
While computing the row values (for the pivot selection) an error could be raised if the row value (the denominator in the division) was equal to 0.
The division should not happen because the pivot value should be greater than 0.

To fix the problem i catch the exception that occurs when the denominator is equal to 0, and append to the list of possible pivots the value 0 as a placeholder (Note : the value could be replaced with anything between ] -inf, 0]. The scope is only to make the lambda test to get the ``row_index`` fail). 